### PR TITLE
cmake build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,6 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 ## Setup platform specific helper defines build variants
 IF(WIN32)
   ADD_DEFINITIONS (-DPTEXUTILS_WIN32 -D_USE_MATH_DEFINES)
-ELSE(WIN32)
-  ADD_DEFINITIONS (-Wextra -Wno-unused-parameter)
-  SET( CMAKE_CXX_FLAGS "-fPIC")
 ENDIF(WIN32)
 
 ## Choose build options

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,12 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -Wall -pedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Wno-unused-parameter")
+endif()
 
 include_directories(${PTEX_INCLUDE_DIR}
                     ${OPENGL_INCLUDE_DIR}


### PR DESCRIPTION
It's possible what minimum cmake version should become 2.6. I'm not sure if all needed Find\* scripts are included with earlier versions.
Even rhel6 includes cmake 2.6.4 now.
