### PR TITLE
FIX: update namespace to latest oiio version 2.1

### DIFF
--- a/src/ptxconvert.cpp
+++ b/src/ptxconvert.cpp
@@ -43,7 +43,7 @@ struct Options {
 } opt;
 
 
-using namespace OpenImageIO;
+using namespace OpenImageIO_v2_1;
 
 template<typename T>
 inline void divalpha(T* data, int npixels, int nchannels, int alphachan, float scale)


### PR DESCRIPTION
the original code works with version less than 2.x, e.g. ubuntu 18 standard package OpenImageIO 1.7.17. it no longer works with 2.1, which is standard package on ubuntu 20 now. however there exists already 2.3 which is using yet a different namespace convention.

```
using namespace OpenImageIO;
using namespace OpenImageIO_v2_1;
using namespace OIIO; // 2.3
```