### PR TITLE
Fix building procedure on latest macOS (Monterey)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,33 @@ IF(WIN32)
   ADD_DEFINITIONS (-DPTEXUTILS_WIN32 -D_USE_MATH_DEFINES)
 ENDIF(WIN32)
 
+# Adjust OpenMP in Clang on Apple platforms
+IF(APPLE)
+    IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        SET(OpenMP_C "${CMAKE_C_COMPILER}" CACHE STRING "" FORCE)
+        SET(OpenMP_C_FLAGS "-fopenmp=libomp -Wno-unused-command-line-argument" CACHE STRING "" FORCE)
+        SET(OpenMP_C_LIB_NAMES "libomp" "libgomp" "libiomp5" CACHE STRING "" FORCE)
+        SET(OpenMP_libomp_LIBRARY ${OpenMP_C_LIB_NAMES} CACHE STRING "" FORCE)
+        SET(OpenMP_libgomp_LIBRARY ${OpenMP_C_LIB_NAMES} CACHE STRING "" FORCE)
+        SET(OpenMP_libiomp5_LIBRARY ${OpenMP_C_LIB_NAMES} CACHE STRING "" FORCE)
+    ENDIF()
+
+    IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        SET(OpenMP_CXX "${CMAKE_CXX_COMPILER}" CACHE STRING "" FORCE)
+        SET(OpenMP_CXX_FLAGS "-fopenmp=libomp -Wno-unused-command-line-argument -Wno-everything" CACHE STRING "" FORCE)
+        SET(OpenMP_CXX_LIB_NAMES "libomp" "libgomp" "libiomp5" CACHE STRING "" FORCE)
+        SET(OpenMP_libomp_LIBRARY ${OpenMP_CXX_LIB_NAMES} CACHE STRING "" FORCE)
+        SET(OpenMP_libgomp_LIBRARY ${OpenMP_CXX_LIB_NAMES} CACHE STRING "" FORCE)
+        SET(OpenMP_libiomp5_LIBRARY ${OpenMP_CXX_LIB_NAMES} CACHE STRING "" FORCE)
+    ENDIF()
+
+    # Default (Command-line tools & Xcode toolchain) compiler won't provide proper OpenMP functionality on macOS.
+    # Compiler obtained from `brew install llvm` will suffice. 
+    # Create a symbolic link for ease of use.
+    SET(CMAKE_CXX_COMPILER clang-omp++ CACHE STRING "C++ compiler" FORCE)
+ENDIF()
+
+
 ## Choose build options
 # Disney specific method of choosing variant
 IF("$ENV{FLAVOR}" STREQUAL "optimize")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ IF(APPLE)
 
     IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         SET(OpenMP_CXX "${CMAKE_CXX_COMPILER}" CACHE STRING "" FORCE)
-        SET(OpenMP_CXX_FLAGS "-fopenmp=libomp -Wno-unused-command-line-argument -Wno-everything" CACHE STRING "" FORCE)
+        SET(OpenMP_CXX_FLAGS "-fopenmp=libomp -Wno-unused-command-line-argument" CACHE STRING "" FORCE)
         SET(OpenMP_CXX_LIB_NAMES "libomp" "libgomp" "libiomp5" CACHE STRING "" FORCE)
         SET(OpenMP_libomp_LIBRARY ${OpenMP_CXX_LIB_NAMES} CACHE STRING "" FORCE)
         SET(OpenMP_libgomp_LIBRARY ${OpenMP_CXX_LIB_NAMES} CACHE STRING "" FORCE)

--- a/cmake/FindOIIO.cmake
+++ b/cmake/FindOIIO.cmake
@@ -25,3 +25,21 @@ find_library( OIIO_LIBRARIES
         /sw/lib
         /opt/local/lib
         DOC "The OIIO library")
+
+# From OIIO changelog - Version: 2.3 (1 Sept 2021)
+#   "All the utility classes are now in libOpenImageIO_Util only and libOpenImageIO depends on and links to libOpenImageIO_Util, 
+#   rather than the utility classes being defined separately in both libraries."
+find_library( OIIO_LIBRARIES_UTIL
+    NAMES
+         OpenImageIO_Util
+    PATHS
+        ${OIIO_LIBRARY_PATH}
+        ${OIIO_PATH}/lib64/
+        ${OIIO_PATH}/lib/
+        /usr/lib64
+        /usr/lib
+        /usr/local/lib64
+        /usr/local/lib
+        /sw/lib
+        /opt/local/lib
+        DOC "The OIIO library utility")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(ptxview ${PTEX_LIBRARIES}
 add_executable(ptxconvert ptxconvert.cpp)
 target_link_libraries(ptxconvert ${PTEX_LIBRARIES}
                                  ${OIIO_LIBRARIES}
+                                 ${OIIO_LIBRARIES_UTIL}
                                  ${ZLIB_LIBRARIES})
 
 install(TARGETS ptxtransfer DESTINATION ${BIN_INSTALL_DIR})

--- a/src/ptxview.cpp
+++ b/src/ptxview.cpp
@@ -25,8 +25,9 @@
 #include <string.h>
 #include <math.h>
 
-#ifdef OSX
-#include <glut.h>
+#ifdef __APPLE__
+#include <OpenGL/gl3.h>
+#include <GL/freeglut.h>
 #else
 #include <GL/freeglut.h>
 #include <GL/glu.h>


### PR DESCRIPTION
This PR includes changes necessary to build PTEX-Utilities on macOS Monterey.

Changes:
- Addition of OpenMP flags for C and C++ compiler on Apple platforms,
- Creation of symbolic link for separate (non-Xcode-toolchain) compiler which supports OpenMP,
- Adjustment of includes for OpenGL on Apple platforms,
- Addition of OpenImageIO Utilities due to separation in recent versions of the library (Version 2.3+).

Builds without any additional warnings (besides deprecation due to OpenGL usage).
Tested on macOS Monterey (Apple Silicon & Intel based Macs).